### PR TITLE
PropTypes has been moved to 'prop-types' library

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ios"
   ],
   "dependencies": {
-    "react-native-root-modal": "~1.0.6"
+    "react-native-root-modal": "~3.1.1"
   },
   "author": "Ken Huang <ken.hky@163.com> ",
   "license": "MIT"


### PR DESCRIPTION
PropTypes has been moved to 'prop-types' library and is no longer available in new version of react lib . Its already updated in the latest version of react-native-root-modal.So. need to update the dependant react-native-root-modal lib version.